### PR TITLE
File tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.18.0+incompatible
 	github.com/charter-oss/structured v0.0.0-20190211172727-b8be75e216c8
+	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jjeffery/errors v1.0.3 // indirect
 	github.com/jjeffery/kv v0.7.0 // indirect
+	github.com/lithammer/dedent v1.1.0
 	github.com/sirupsen/logrus v1.4.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
 	github.com/spf13/viper v0.0.0-00010101000000-000000000000

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,10 @@ require (
 	github.com/jjeffery/errors v1.0.3 // indirect
 	github.com/jjeffery/kv v0.7.0 // indirect
 	github.com/sirupsen/logrus v1.4.1 // indirect
-	github.com/spf13/viper v1.3.2-0.20190315063904-3954e415200e
+	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
+	github.com/spf13/viper v0.0.0-00010101000000-000000000000
+	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
 
-replace github.com/spf13/viper v1.3.2 => github.com/demond2/viper v1.3.2
+replace github.com/spf13/viper => ../../demond2/viper

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/jjeffery/kv v0.7.0/go.mod h1:l0/cyIcKU91Y916GzHYy6dN0opoZ/hJ1PuV2VaHb
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
+github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/demond2/viper v1.3.2 h1:L+ICx8coVxpCbvdynWFSzwlAIieXxIap2lOCp9KxwK8=
+github.com/demond2/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -22,6 +24,7 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ER
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
@@ -32,6 +35,8 @@ github.com/jjeffery/errors v1.0.3 h1:oM8cLCCNP8ccKKpn7tbii4AW5hqZsr2pvEXxvwVoBUs
 github.com/jjeffery/errors v1.0.3/go.mod h1:K2Ea6XpV2ki89b7/nPp5DVHqMuTvcbv6q95/XkzvXx8=
 github.com/jjeffery/kv v0.7.0 h1:3C2C38927WyP4rr/FjqUWoCtlSz5lUtt6ZD6U5UGiUw=
 github.com/jjeffery/kv v0.7.0/go.mod h1:l0/cyIcKU91Y916GzHYy6dN0opoZ/hJ1PuV2VaHbRhc=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -43,6 +48,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
+github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
@@ -51,8 +60,6 @@ github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/viper v1.3.2-0.20190315063904-3954e415200e h1:YV/g37tLgXCG/XU+ZvYjCy+ks/0OFZaRLhIFOwLO5Fk=
-github.com/spf13/viper v1.3.2-0.20190315063904-3954e415200e/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -60,11 +67,20 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
+golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1YthsFqr/5mxHduZW2A=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/import.go
+++ b/import.go
@@ -29,7 +29,7 @@ func (yp *Yp) Import(s string, r io.Reader) error {
 	return yp.YamlParse(s)
 }
 
-//Import reads data from a single YAML file and adds its data to this *Yp instance
+//ImportFile reads data from a single YAML file and adds its data to this *Yp instance
 func (yp *Yp) ImportFile(s string) error {
 	r, err := os.Open(s)
 	if err != nil {
@@ -58,6 +58,7 @@ func (yp *Yp) YamlParse(name string) error {
 				}).Wrap(err, "failed to parse yaml section")
 			}
 			section.Viper = vp
+			section.File = k
 		}
 	}
 	return nil

--- a/section.go
+++ b/section.go
@@ -4,6 +4,7 @@ import "github.com/spf13/viper"
 
 //YamlFile stores raw file bytes and Viper struct
 type YamlSection struct {
+	File          string //the file from which the section originates
 	Bytes         []byte
 	OriginalBytes []byte // Pre-template functions
 	Viper         *viper.Viper

--- a/section_test.go
+++ b/section_test.go
@@ -1,0 +1,17 @@
+package yamlpack
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSection(t *testing.T) {
+	yp := New()
+	Convey("", t, func() {
+
+	})
+}
+
+
+sectionData := dedent.

--- a/section_test.go
+++ b/section_test.go
@@ -1,17 +1,59 @@
 package yamlpack
 
 import (
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/lithammer/dedent"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSection(t *testing.T) {
-	yp := New()
-	Convey("", t, func() {
-
+	Convey("sections from reader", t, func() {
+		yp := New()
+		err := yp.Import("file1", sectionData())
+		So(err, ShouldBeNil)
+		Convey("Can export generate *Sections", func() {
+			sections := yp.AllSections()
+			So(sections, ShouldHaveLength, 2)
+			Convey("can read exported sections", func() {
+				sectionNumber := sections[0].GetString("SectionNumber")
+				So(sectionNumber, ShouldEqual, "1")
+			})
+			Convey("exported sections have File name", func() {
+				So(sections[0].File, ShouldEqual, "file1")
+			})
+		})
 	})
+	Convey("sections from file", t, func() {
+		yp := New()
+		err := yp.ImportFile("testdata/filenameTest.yaml")
+		So(err, ShouldBeNil)
+		Convey("Can export generate *Sections", func() {
+			sections := yp.AllSections()
+			So(sections, ShouldHaveLength, 1)
+			Convey("exported sections have File name", func() {
+				So(sections[0].File, ShouldEqual, "testdata/filenameTest.yaml")
+			})
+			Convey("section can export subsection", func() {
+				subSection, err := sections[0].Sub("subField")
+				So(err, ShouldBeNil)
+				So(subSection, ShouldNotBeNil)
+				Convey("sub sections have File", func() {
+					So(subSection.File, ShouldEqual, "testdata/filenameTest.yaml")
+				})
+			})
+		})
+	})
+
 }
 
-
-sectionData := dedent.
+func sectionData() io.Reader {
+	return strings.NewReader(dedent.Dedent(`
+		---
+		SectionNumber: 1
+		---
+		SectionNumber: 2
+	`))
+}

--- a/testdata/filenameTest.yaml
+++ b/testdata/filenameTest.yaml
@@ -1,0 +1,8 @@
+---
+subField:
+  subSection1:
+    - item1
+    - item2
+  subSection2:
+    - item3
+    - item4

--- a/yamlpack.go
+++ b/yamlpack.go
@@ -133,6 +133,7 @@ func (section *YamlSection) Sub(identifier string) (*YamlSection, error) {
 		return nil, err
 	}
 	return &YamlSection{
+		File:         section.File,
 		Bytes:        marshaledBytes,
 		Viper:        viperSub,
 		TemplateFunc: section.TemplateFunc,

--- a/yamlpack_test.go
+++ b/yamlpack_test.go
@@ -1,16 +1,15 @@
 package yamlpack
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNew(t *testing.T) {
-	yp := New()
-	if yp == nil {
-		t.Errorf("New() *Yp instance was nil")
-	}
-	if reflect.TypeOf(yp.Handlers) != reflect.TypeOf((map[string]func(string) error)(nil)) {
-		t.Errorf("*Yp.Handlers does not contain 'map[string]func(string) error'")
-	}
+	Convey("New yamlpack", t, func() {
+		yp := New()
+		So(yp, ShouldNotBeNil)
+		So(yp, ShouldHaveSameTypeAs, &Yp{})
+	})
 }


### PR DESCRIPTION
Adds the ability to track yaml source file within yaml sections

Keeping track of the originating yaml file is needed for yaml parse error reporting and data that must be computed relative to the source file location, mainly relative file paths as data elements.